### PR TITLE
Do not run ci on dev and production branches

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -2,6 +2,9 @@ name: "Backend Checks"
 
 on:
   push:
+    branches-ignore:
+      - dev
+      - production
     paths:
       - backend/**
 

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -2,6 +2,9 @@ name: "Frontend Checks"
 
 on:
   push:
+    branches-ignore:
+      - dev
+      - production
     paths:
       - frontend/**
 


### PR DESCRIPTION
ci runs on pushes to all another branches, so it is not necessary to do it on dev and production branches, otherwise ci jobs will be duplicated on pushed to dev and production branches